### PR TITLE
Add Ability to Fetch Energy Usage Data

### DIFF
--- a/aioschluter/const.py
+++ b/aioschluter/const.py
@@ -2,6 +2,7 @@
 
 API_BASE_URL = "https://ditra-heat-e-wifi.schluter.com"
 API_AUTH_URL = API_BASE_URL + "/api/authenticate/user"
+API_GET_ENERGY_USAGE_URL = API_BASE_URL + "/api/energyusage"
 API_GET_THERMOSTATS_URL = API_BASE_URL + "/api/thermostats"
 API_SET_THERMOSTAT_URL = API_BASE_URL + "/api/thermostat"
 API_APPLICATION_ID = 7

--- a/aioschluter/thermostat.py
+++ b/aioschluter/thermostat.py
@@ -1,6 +1,25 @@
+from enum import Enum
+
+class EnergyCalculationDuration(Enum):
+    DAY = "Day"
+    WEEK = "Week"
+    MONTH = "Month"
+
+class DayEnergyUsage:
+    def __init__(self, json):
+        usage_jsons = json["Usage"]
+        hour_usages = []
+        for index, usage_json in enumerate(usage_jsons):
+            hour_usages.append(HourEnergyUsage(usage_json, index))
+
+        self.hour_usages = hour_usages
+
+class HourEnergyUsage:
+    def __init__(self, json, time):
+        self.energy_in_kwh = json["EnergyKWattHour"]
+        self.time = time
+
 """ A single instance of a Schluter Thermostat """
-
-
 class Thermostat:
     """A Schluter Thermostat"""
 
@@ -37,6 +56,7 @@ class Thermostat:
         self._is_assigned = data["HasBeenAssigned"]
         self._distributer_id = data["DistributerId"]
         self._support = data["Support"]
+        self._day_energy_usages = [] # populated async
 
     def __repr__(self):
         """Print Method."""
@@ -116,3 +136,11 @@ class Thermostat:
     def sw_version(self):
         """Software Version of the Thermostat."""
         return self._sw_version
+    
+    @property
+    def day_energy_usages(self):
+        """Energy usage per day"""
+        return self._day_energy_usages
+    
+    def update_energy_usage(self, day_energy_usages):
+        self._day_energy_usages = day_energy_usages


### PR DESCRIPTION
Add fetching energy usage data from the `energyusage` endpoint on a per thermostat basis. The data is the cumulative energy used based on the period of time specified (included today, last 7 days, last 30 days). 

The date calculated for the `today` param will use the timezone of the machine, so it is important to set the timezone if using a Docker container. Otherwise, you may end up fetching the wrong date